### PR TITLE
Fix ModuleNotFoundError: No module named 'setuptools_rust' when installing netmiko using pip3 (ansible-install)

### DIFF
--- a/ansible-install/utm.yml
+++ b/ansible-install/utm.yml
@@ -20,10 +20,17 @@
       - python36-pip
       - python-setuptools 
 
+  - name: Update pip itself (required by netmiko)
+    pip: 
+      name: pip
+      executable: pip3.6
+      state: latest
+    
   - name: Install ucsmsdk and netmiko package via pip
     pip:
       name: "{{ packages }}"
       executable: pip3.6
+      state: latest
     vars:
       packages:
       - ucsmsdk


### PR DESCRIPTION
Hi,

This fix an error where pip failed to install netmiko with the base pip version available with CentOS 7 (actual latest release).  Also, ucsmsdk and netmiko will be update if a new version is available.

I did not open a issue since it was not really really one with UTM itself.  Just let me know if you want me to proceed otherwise.

By the way, the new version is very nice, more intuitive for an occasionnal users.  Nicely done !

Regards,