### PR TITLE
Fixed to allow to deploy UTM on Linux 8 (ansible-install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ and much more...
 - Python version: Version 3 only. Should be able to work on Python 2 also with minor modification.
 
 Two options:
-- DIY Installation: Self install the required pacakges
+- DIY Installation: Self install the required packages (or take a look to [ansible-install](ansible-install) folder where you could let the machine work for you)
 - OVA - Required packages are pre-installed on CentOS 7.6 OVA
 
 ### DIY Installation

--- a/ansible-install/.gitignore
+++ b/ansible-install/.gitignore
@@ -1,2 +1,3 @@
 .vagrant/
+inventory.test
 vdm/

--- a/ansible-install/README.md
+++ b/ansible-install/README.md
@@ -14,7 +14,7 @@ These instruction should allow you to use ansible to deploy UTM.  Also, if like 
 
 <br>
 
-- For production deployment, you should have a access to a Redhat based Linux system (Redhat, CentOS, Oracle Linux).  Installation tests took place on CentOS.
+- For production deployment, you should have a access to a Redhat based Linux system (Redhat, CentOS, Oracle Linux).  Installation tests took place on CentOS 7 and Oracle Linux 8.
 
 - You must have an ssh access to this system and a user that is allowed to run commands as root (sudo)
 
@@ -27,10 +27,10 @@ These instruction should allow you to use ansible to deploy UTM.  Also, if like 
 
 - If you want to be up and running faster, for testing purposes, you can use tool like Vagrant to provision a "local" VM and deploy the UTM stack on it.  In fact, the ansible-install playbooks and been tested this way.  The actual test environnement was :
     
-    - Ubuntu 20.04 running under WSL 1 on Windows 10 (2004)
-    - Vagrant 2.2.10
+    - Ubuntu 20.04 running under WSL 1 on Windows 10 (21H1)
+    - Vagrant 2.2.19
 
-- You must have a functionnal ansible installation (tested on 2.9.6)
+- You must have a functionnal ansible installation (tested on 2.9.27)
 
 <br>
 

--- a/ansible-install/Vagrantfile
+++ b/ansible-install/Vagrantfile
@@ -11,8 +11,12 @@ Vagrant.configure("2") do |config|
   # https://docs.vagrantup.com.
 
   # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "centos/7"
+  # boxes at https://vagrantcloud.com/search
+  config.vm.box = "oraclelinux/8"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "https://oracle.github.io/vagrant-projects/boxes/oraclelinux/8.json"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -23,7 +27,8 @@ Vagrant.configure("2") do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # NOTE: This will enable public access to the opened port
-  config.vm.network "forwarded_port", guest: 3000, host: 3000
+  config.vm.network "forwarded_port", id: "ssh"    , guest: 22  , host: 2201
+  config.vm.network "forwarded_port", id: "grafana", guest: 3000, host: 3001
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine and only allow access
@@ -63,8 +68,9 @@ Vagrant.configure("2") do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   apt-get update
-  #   apt-get install -y apache2
-  # SHELL
+  config.vm.provision "shell", inline: <<-SHELL
+     sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+     systemctl restart sshd
+     echo "vagrant" | passwd vagrant --stdin
+  SHELL
 end

--- a/ansible-install/inventory
+++ b/ansible-install/inventory
@@ -28,6 +28,3 @@ update_image=false
 
 # Update existing dashboard
 import_grafana_dashboard=true
-
-# InfluxDB version (via package name : influxdb is v1, influxdb2 is v2)
-influxdb_package=influxdb

--- a/ansible-install/inventory
+++ b/ansible-install/inventory
@@ -1,8 +1,10 @@
 [utm]
-vagrant ansible_ssh_host=127.0.0.1 ansible_ssh_port=2201 ansible_ssh_user='vagrant' ansible_ssh_private_key_file='.vagrant/machines/default/virtualbox/private_key'
+vagrant ansible_ssh_host=127.0.0.1 ansible_ssh_port=2201 ansible_ssh_user='vagrant' ansible_ssh_pass='vagrant'
 
 
 [all:vars]
+ansible_python_interpreter=auto_silent
+ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 
 # System timezone
 timezone="America/Toronto"
@@ -26,3 +28,6 @@ update_image=false
 
 # Update existing dashboard
 import_grafana_dashboard=true
+
+# InfluxDB version (via package name : influxdb is v1, influxdb2 is v2)
+influxdb_package=influxdb

--- a/ansible-install/utm.yml
+++ b/ansible-install/utm.yml
@@ -9,60 +9,6 @@
   tasks:
 
 
-  - name: Check for downgrade of influxdb - not supported
-    shell:
-      cmd: rpm -qa | grep -c influxdb2
-      warn: false
-    register: shell_check_downgrade
-    failed_when: false
-    changed_when: false
-
-  - fail:
-      msg: Downgrade influxdb is not supported - check influxdb_package variable for details
-    when: influxdb_package == "influxdb" and shell_check_downgrade.stdout != "0"
-
-
-  - name: Check for upgrade of influxdb
-    shell:
-      cmd: rpm -qa | grep influxdb | grep -v '\-cli\-' | cut -d '-' -f1
-      warn: false
-    register: shell_check_upgrade
-    failed_when: false
-    changed_when: false
-
-  - name: Stop telegraf service (upgrade of influxdb)
-    service:
-      name: telegraf
-      state: stopped
-    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
-
-  - name: Stop influxdb service (upgrade of influxdb)
-    service:
-      name: influxdb
-      state: stopped
-    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
-
-  - name: Backup of influxdb v1
-    shell:
-      cmd: influx_inspect export -database telegraf -datadir /var/lib/influxdb/data -waldir /var/lib/influxdb/wal -retention autogen -out /tmp/telegraf.data -lponly
-    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
-
-  - name: Remove of influxdb (upgrade)
-    yum:
-      name: influxdb 
-      state: absent
-    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
-
-  - name: Clean up before influxdb v2
-    file:
-      path: "{{ item }}"
-      state: absent
-    with_items:
-      - /etc/influxdb
-      - /var/lib/influxdb/
-    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
-
-
   - name: Install required package - UTM
     yum:
       name: "{{ packages }}"
@@ -138,61 +84,14 @@
 
   - name: Install influxdb
     yum:
-      name: "{{ influxdb_package }}"
+      name: influxdb
       state: latest
-
-  - name: Install influxdb - client (if influxdb2 is installed)
-    yum:
-      name: influxdb2-cli
-      state: latest
-    when: influxdb_package == "influxdb2"
 
   - name: Enable service influxdb
     service:
       name: influxdb
       enabled: yes
       state: started
-
-
-  - name: Setup influxdb 2.x (if required)
-    shell:
-      cmd: |
-        influx setup --org utm --bucket telegraf --retention 0 --force --username utm --password utmPassword
-    register: shell_influx_setup
-    changed_when: '"instance has already been set up" not in shell_influx_setup.stderr'
-    failed_when: shell_influx_setup.rc != 0 and "instance has already been set up" not in shell_influx_setup.stderr
-    when: influxdb_package == "influxdb2"
-
-  - name: Get Token for influxdb 2.x operation (if required)
-    shell:
-      cmd: |
-        influx auth list | grep "utm's Token" | awk '{ print $4 }'
-    changed_when: false
-    register: shell_influx_token
-    when: influxdb_package == "influxdb2"
-
-  - name: Get bucket-id for influxdb 2.x operation (if required)
-    shell:
-      cmd: |
-        influx bucket list | grep "telegraf" | awk '{ print $1 }'
-    changed_when: false
-    register: shell_influx_bucketid
-    when: influxdb_package == "influxdb2"
-
-  - name: Setup dbrp for influxdb 2.x (if required)
-    shell:
-      cmd: |
-        influx v1 dbrp create --db telegraf --rp autogen --bucket-id {{ shell_influx_bucketid.stdout }} --default
-    register: shell_influx_dbrp
-    changed_when: '"another DBRP mapping with same" not in shell_influx_dbrp.stderr'
-    failed_when: shell_influx_dbrp.rc != 0 and "another DBRP mapping with same" not in shell_influx_dbrp.stderr
-    when: influxdb_package == "influxdb2"
-
-  - name: Restore of influxdb v1 if upgrading influxdb
-    shell:
-      cmd: influx write --bucket telegraf --file /tmp/telegraf.data
-    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
-
 
   - name: Install telegraf
     yum:
@@ -205,17 +104,6 @@
       enabled: yes
       state: started
 
-
-  - name: Remove influxdb datasource if upgrading influxdb
-    grafana_datasource:
-      url_username: admin
-      url_password: admin
-      grafana_url: "http://localhost:3000"
-      name: "InfluxDB"
-      ds_type: "influxdb"
-      ds_url: "http://localhost:8086"
-      state: absent
-    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
 
   - name: Check if InfluxDB datasource exists in grafana
     uri:
@@ -236,22 +124,7 @@
       ds_type: "influxdb"
       ds_url: "http://localhost:8086"
       database: "telegraf"
-    when: influxdb_package == "influxdb" and grafana_ds.status == 404
-
-  - name: Create influxdb datasource (for influxdb2)
-    grafana_datasource:
-      url_username: admin
-      url_password: admin
-      grafana_url: "http://localhost:3000"
-      name: "InfluxDB"
-      ds_type: "influxdb"
-      ds_url: "http://localhost:8086"
-      database: "telegraf"
-      additional_json_data:
-        httpHeaderName1: "Authorization"
-      additional_secure_json_data:
-        httpHeaderValue1: "Token {{ shell_influx_token.stdout }}"
-    when: influxdb_package == "influxdb2" and grafana_ds.status == 404
+    when: grafana_ds.status == 404
 
 
   - name: Create directory /usr/local/telegraf
@@ -325,38 +198,6 @@
       regexp: '^#   # ignore_protocol_stats = false'
       line: '  ignore_protocol_stats = true'
 
-  - name: Update telegraf base configuration /etc/telegraf/telegraf.conf - [[outputs.influxdb]] - influxdb2 only
-    lineinfile:
-      path: /etc/telegraf/telegraf.conf
-      regexp: '^\[\[outputs.influxdb\]\]'
-      line: '# [[outputs.influxdb]]'
-    when: influxdb_package == "influxdb2"
-
-  - name: Update telegraf base configuration /etc/telegraf/telegraf.conf - [[outputs.influxdb_v2]] - influxdb2 only
-    replace:
-      path: /etc/telegraf/telegraf.conf
-      regexp: '^# # Configuration for sending metrics to InfluxDB$\n^# \[\[outputs.influxdb_v2\]\]$\n[\s\S]*^#   bucket = \"\"$\n^#$\n^#'
-      replace: |-
-        # Configuration for sending metrics to InfluxDB
-        [[outputs.influxdb_v2]]
-        ## The URLs of the InfluxDB cluster nodes.
-        ##
-        ## Multiple URLs can be specified for a single cluster, only ONE of the
-        ## urls will be written to each interval.
-        ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
-        urls = ["http://127.0.0.1:8086"]
-
-        ## Token for authentication.
-        token = "{{ shell_influx_token.stdout }}"
-
-        ## Organization is the name of the organization you wish to write to; must exist.
-        organization = "utm"
-
-        ## Destination bucket to write into.
-        bucket = "telegraf"
-
-        #
-    when: influxdb_package == "influxdb2"
 
   - name: Add /etc/telegraf/telegraf.d/utm.conf
     copy:
@@ -384,7 +225,7 @@
     service:
       name: telegraf
       state: restarted
-    when: telegraf_cfg.changed or (influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb")
+    when: telegraf_cfg.changed
 
 
   - name: Create directory /usr/share/grafana/public/img/utm

--- a/ansible-install/utm.yml
+++ b/ansible-install/utm.yml
@@ -9,6 +9,60 @@
   tasks:
 
 
+  - name: Check for downgrade of influxdb - not supported
+    shell:
+      cmd: rpm -qa | grep -c influxdb2
+      warn: false
+    register: shell_check_downgrade
+    failed_when: false
+    changed_when: false
+
+  - fail:
+      msg: Downgrade influxdb is not supported - check influxdb_package variable for details
+    when: influxdb_package == "influxdb" and shell_check_downgrade.stdout != "0"
+
+
+  - name: Check for upgrade of influxdb
+    shell:
+      cmd: rpm -qa | grep influxdb | grep -v '\-cli\-' | cut -d '-' -f1
+      warn: false
+    register: shell_check_upgrade
+    failed_when: false
+    changed_when: false
+
+  - name: Stop telegraf service (upgrade of influxdb)
+    service:
+      name: telegraf
+      state: stopped
+    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
+
+  - name: Stop influxdb service (upgrade of influxdb)
+    service:
+      name: influxdb
+      state: stopped
+    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
+
+  - name: Backup of influxdb v1
+    shell:
+      cmd: influx_inspect export -database telegraf -datadir /var/lib/influxdb/data -waldir /var/lib/influxdb/wal -retention autogen -out /tmp/telegraf.data -lponly
+    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
+
+  - name: Remove of influxdb (upgrade)
+    yum:
+      name: influxdb 
+      state: absent
+    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
+
+  - name: Clean up before influxdb v2
+    file:
+      path: "{{ item }}"
+      state: absent
+    with_items:
+      - /etc/influxdb
+      - /var/lib/influxdb/
+    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
+
+
   - name: Install required package - UTM
     yum:
       name: "{{ packages }}"
@@ -16,25 +70,28 @@
     vars:
       packages:
       - "@Development tools"
-      - python36
-      - python36-pip
-      - python-setuptools 
-
-  - name: Update pip itself (required by netmiko)
-    pip: 
-      name: pip
-      executable: pip3.6
-      state: latest
+      - python3
+      - python3-setuptools
     
-  - name: Install ucsmsdk and netmiko package via pip
-    pip:
-      name: "{{ packages }}"
-      executable: pip3.6
-      state: latest
-    vars:
-      packages:
-      - ucsmsdk
-      - netmiko
+
+  - name: Update pip itself (required by netmiko) using shell (ansible module is failing on CentOS7)
+    shell:
+      cmd: python3 -m pip install pip==21.3.1 -U  # Required to use python 3.6
+    register: shell_pip_install
+    changed_when: '"Requirement already satisfied: pip==21.3.1" not in shell_pip_install.stdout'
+
+  - name: Install ucsmsdk via pip using shell (ansible module is failing on CentOS7)
+    shell:
+      cmd: python3 -m pip install ucsmsdk
+    register: shell_pip_install
+    changed_when: '"Requirement already satisfied: ucsmsdk" not in shell_pip_install.stdout'
+
+  - name: Install netmiko==4.0.0 via pip using shell (ansible module is failing on CentOS7)
+    shell:
+      cmd: python3 -m pip install netmiko==4.0.0  # Required to use python 3.6
+    register: shell_pip_install
+    changed_when: '"Requirement already satisfied: netmiko==4.0.0" not in shell_pip_install.stdout'
+
 
   - name: Enable service chronyd
     service:
@@ -74,21 +131,67 @@
   - name: Add YUM repository influxdb.repo (will be use for influxdb and telegraf)
     yum_repository:
       name: influxdb
-      description: https://docs.influxdata.com/influxdb/v1.8/introduction/install/ 
-      baseurl: https://repos.influxdata.com/rhel/\$releasever/\$basearch/stable/
+      description: InfluxDB Repository - RHEL $releasever
+      baseurl: https://repos.influxdata.com/rhel/$releasever/$basearch/stable/
       gpgcheck: yes
       gpgkey: https://repos.influxdata.com/influxdb.key
 
   - name: Install influxdb
     yum:
-      name: influxdb
+      name: "{{ influxdb_package }}"
       state: latest
+
+  - name: Install influxdb - client (if influxdb2 is installed)
+    yum:
+      name: influxdb2-cli
+      state: latest
+    when: influxdb_package == "influxdb2"
 
   - name: Enable service influxdb
     service:
       name: influxdb
       enabled: yes
       state: started
+
+
+  - name: Setup influxdb 2.x (if required)
+    shell:
+      cmd: |
+        influx setup --org utm --bucket telegraf --retention 0 --force --username utm --password utmPassword
+    register: shell_influx_setup
+    changed_when: '"instance has already been set up" not in shell_influx_setup.stderr'
+    failed_when: shell_influx_setup.rc != 0 and "instance has already been set up" not in shell_influx_setup.stderr
+    when: influxdb_package == "influxdb2"
+
+  - name: Get Token for influxdb 2.x operation (if required)
+    shell:
+      cmd: |
+        influx auth list | grep "utm's Token" | awk '{ print $4 }'
+    changed_when: false
+    register: shell_influx_token
+    when: influxdb_package == "influxdb2"
+
+  - name: Get bucket-id for influxdb 2.x operation (if required)
+    shell:
+      cmd: |
+        influx bucket list | grep "telegraf" | awk '{ print $1 }'
+    changed_when: false
+    register: shell_influx_bucketid
+    when: influxdb_package == "influxdb2"
+
+  - name: Setup dbrp for influxdb 2.x (if required)
+    shell:
+      cmd: |
+        influx v1 dbrp create --db telegraf --rp autogen --bucket-id {{ shell_influx_bucketid.stdout }} --default
+    register: shell_influx_dbrp
+    changed_when: '"another DBRP mapping with same" not in shell_influx_dbrp.stderr'
+    failed_when: shell_influx_dbrp.rc != 0 and "another DBRP mapping with same" not in shell_influx_dbrp.stderr
+    when: influxdb_package == "influxdb2"
+
+  - name: Restore of influxdb v1 if upgrading influxdb
+    shell:
+      cmd: influx write --bucket telegraf --file /tmp/telegraf.data
+    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
 
 
   - name: Install telegraf
@@ -103,6 +206,17 @@
       state: started
 
 
+  - name: Remove influxdb datasource if upgrading influxdb
+    grafana_datasource:
+      url_username: admin
+      url_password: admin
+      grafana_url: "http://localhost:3000"
+      name: "InfluxDB"
+      ds_type: "influxdb"
+      ds_url: "http://localhost:8086"
+      state: absent
+    when: influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb"
+
   - name: Check if InfluxDB datasource exists in grafana
     uri:
       url_username: admin
@@ -113,7 +227,7 @@
       status_code: 200, 404
     register: grafana_ds
 
-  - name: Create influxdb datasource
+  - name: Create influxdb datasource (for influxdb)
     grafana_datasource:
       url_username: admin
       url_password: admin
@@ -122,7 +236,22 @@
       ds_type: "influxdb"
       ds_url: "http://localhost:8086"
       database: "telegraf"
-    when: grafana_ds.status == 404
+    when: influxdb_package == "influxdb" and grafana_ds.status == 404
+
+  - name: Create influxdb datasource (for influxdb2)
+    grafana_datasource:
+      url_username: admin
+      url_password: admin
+      grafana_url: "http://localhost:3000"
+      name: "InfluxDB"
+      ds_type: "influxdb"
+      ds_url: "http://localhost:8086"
+      database: "telegraf"
+      additional_json_data:
+        httpHeaderName1: "Authorization"
+      additional_secure_json_data:
+        httpHeaderValue1: "Token {{ shell_influx_token.stdout }}"
+    when: influxdb_package == "influxdb2" and grafana_ds.status == 404
 
 
   - name: Create directory /usr/local/telegraf
@@ -194,8 +323,40 @@
     lineinfile:
       path: /etc/telegraf/telegraf.conf
       regexp: '^#   # ignore_protocol_stats = false'
-      line: '    ignore_protocol_stats = true'
+      line: '  ignore_protocol_stats = true'
 
+  - name: Update telegraf base configuration /etc/telegraf/telegraf.conf - [[outputs.influxdb]] - influxdb2 only
+    lineinfile:
+      path: /etc/telegraf/telegraf.conf
+      regexp: '^\[\[outputs.influxdb\]\]'
+      line: '# [[outputs.influxdb]]'
+    when: influxdb_package == "influxdb2"
+
+  - name: Update telegraf base configuration /etc/telegraf/telegraf.conf - [[outputs.influxdb_v2]] - influxdb2 only
+    replace:
+      path: /etc/telegraf/telegraf.conf
+      regexp: '^# # Configuration for sending metrics to InfluxDB$\n^# \[\[outputs.influxdb_v2\]\]$\n[\s\S]*^#   bucket = \"\"$\n^#$\n^#'
+      replace: |-
+        # Configuration for sending metrics to InfluxDB
+        [[outputs.influxdb_v2]]
+        ## The URLs of the InfluxDB cluster nodes.
+        ##
+        ## Multiple URLs can be specified for a single cluster, only ONE of the
+        ## urls will be written to each interval.
+        ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
+        urls = ["http://127.0.0.1:8086"]
+
+        ## Token for authentication.
+        token = "{{ shell_influx_token.stdout }}"
+
+        ## Organization is the name of the organization you wish to write to; must exist.
+        organization = "utm"
+
+        ## Destination bucket to write into.
+        bucket = "telegraf"
+
+        #
+    when: influxdb_package == "influxdb2"
 
   - name: Add /etc/telegraf/telegraf.d/utm.conf
     copy:
@@ -223,7 +384,7 @@
     service:
       name: telegraf
       state: restarted
-    when: telegraf_cfg.changed
+    when: telegraf_cfg.changed or (influxdb_package == "influxdb2" and shell_check_upgrade.stdout == "influxdb")
 
 
   - name: Create directory /usr/share/grafana/public/img/utm

--- a/ansible-install/utm.yml
+++ b/ansible-install/utm.yml
@@ -115,7 +115,7 @@
       status_code: 200, 404
     register: grafana_ds
 
-  - name: Create influxdb datasource (for influxdb)
+  - name: Create influxdb datasource
     grafana_datasource:
       url_username: admin
       url_password: admin

--- a/ansible-install/utm.yml
+++ b/ansible-install/utm.yml
@@ -248,8 +248,6 @@
     with_items:
       - agenty-flowcharting-panel
       - grafana-piechart-panel
-      - larona-epict-panel
-      - michaeldmoore-multistat-panel
     register: grafana_plugin
 
   - name: Restart grafana service (if plugins has been installed or configuration has changed)


### PR DESCRIPTION
Hi,

This allow to use ansible-install on Linux 7 or 8 (tested on CentOS7 / OL8).  I did also add the possibility of using influxdb2.x (this is not the default). I also add a reference to ansible-install from the UTM main readme.

I did not open a issue since it was not really really one with UTM itself. Just let me know if you want me to proceed otherwise.

Regards,